### PR TITLE
PROLL-161: GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,41 @@
+name: Pages
+
+on:
+  push:
+    branches:
+      - develop
+      - PROLL-161/gh-pages
+
+jobs:
+  pages:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # If your repository depends on submodule, please see: https://github.com/actions/checkout
+          submodules: recursive
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+      - name: Cache NPM dependencies
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.OS }}-npm-cache
+          restore-keys: |
+            ${{ runner.OS }}-npm-cache
+      - name: Install Dependencies
+        working-directory: ./algrtm
+        run: npm install
+      - name: Build
+        working-directory: ./algrtm
+        run: npm run build
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./algrtm/out

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Build
         working-directory: ./algrtm
         run: npm run build
+      - name: Create CNAME
+        working-directory: ./algrtm
+        run: echo "nospoko.com" > out/CNAME
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/algrtm/next.config.js
+++ b/algrtm/next.config.js
@@ -1,9 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
-
-  basePath: '/algrtm',
-  assetPrefix: '/algrtm',
  
   // Optional: Change links `/me` -> `/me/` and emit `/me.html` -> `/me/index.html`
   // trailingSlash: true,

--- a/algrtm/next.config.js
+++ b/algrtm/next.config.js
@@ -3,6 +3,7 @@ const nextConfig = {
   output: 'export',
 
   basePath: '/algrtm',
+  assetPrefix: '/algrtm',
  
   // Optional: Change links `/me` -> `/me/` and emit `/me.html` -> `/me/index.html`
   // trailingSlash: true,

--- a/algrtm/next.config.js
+++ b/algrtm/next.config.js
@@ -1,6 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
+
+  basePath: '/algrtm',
  
   // Optional: Change links `/me` -> `/me/` and emit `/me.html` -> `/me/index.html`
   // trailingSlash: true,

--- a/algrtm/next.config.js
+++ b/algrtm/next.config.js
@@ -1,0 +1,15 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+ 
+  // Optional: Change links `/me` -> `/me/` and emit `/me.html` -> `/me/index.html`
+  // trailingSlash: true,
+ 
+  // Optional: Prevent automatic `/me` -> `/me/`, instead preserve `href`
+  // skipTrailingSlashRedirect: true,
+ 
+  // Optional: Change the output directory `out` -> `dist`
+  // distDir: 'dist',
+}
+ 
+module.exports = nextConfig

--- a/algrtm/next.config.mjs
+++ b/algrtm/next.config.mjs
@@ -1,4 +1,0 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {};
-
-export default nextConfig;

--- a/algrtm/next.config.mjs
+++ b/algrtm/next.config.mjs
@@ -12,4 +12,4 @@ const nextConfig = {
   // distDir: 'dist',
 }
  
-module.exports = nextConfig
+export default nextConfig;

--- a/algrtm/next.config.mjs
+++ b/algrtm/next.config.mjs
@@ -1,15 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
- 
-  // Optional: Change links `/me` -> `/me/` and emit `/me.html` -> `/me/index.html`
-  // trailingSlash: true,
- 
-  // Optional: Prevent automatic `/me` -> `/me/`, instead preserve `href`
-  // skipTrailingSlashRedirect: true,
- 
-  // Optional: Change the output directory `out` -> `dist`
-  // distDir: 'dist',
 }
  
 export default nextConfig;


### PR DESCRIPTION
I changed the gh-pages deployment to work with a dedicated domain: https://nospoko.com - no there's no need for additional path management :tada:

The idea is to use this for QA during development, and when it's ready we'll switch it to algrtm.com

---

### Outdated

I've set up a github action to deploy this page to: https://nospoko.github.io/algrtm. To get Next to build static assets I followed this: https://nextjs.org/docs/app/building-your-application/deploying/static-exports which required me to change the extension and content of the `next.config.(m)js` file. 

The automatic deployment works, but the config change messed up something about the paths, in the deployed version there's an issue with this icon:

<img width="321" alt="Screenshot 2024-02-19 at 19 06 00" src="https://github.com/Nospoko/algrtm/assets/8056825/6d1abfc9-5778-43c6-9f2a-9bbcef1adfc2">

and locally all paths are confused, and the same icon is missing 🥲 

<img width="321" alt="image" src="https://github.com/Nospoko/algrtm/assets/8056825/3f74d079-aea4-47fa-abf8-928462cb4daa">

I'm assuming this should be an easy fix - let me know if there's something fundamentally wrong with my approach :)


